### PR TITLE
docs: organisation URL change

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ cmsenv
 Clone the repo:
 
 ```
-git clone https://github.com/katilp/pattuples2011.git 
+git clone https://github.com/cms-opendata-analyses/pattuples2011
 cd pattuples2011
 ```
 


### PR DESCRIPTION
- Changes `katilp` to `cms-opendata-analyses` following up
  the donation of the respository to the new organisation.
  (closes #2)

Signed-off-by: Lukas Holub luc.holub@gmail.com
